### PR TITLE
Add args to format! calls

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -26,12 +26,12 @@ pub enum SerdeError {
 
 impl ser::Error for SerdeError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        SerdeError::Serialize(format!("Failed to serialize: {msg}"))
+        SerdeError::Serialize(format!("Failed to serialize: {msg}", msg = msg))
     }
 }
 
 impl de::Error for SerdeError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        SerdeError::Deserialize(format!("Failed to deserialize: {msg}"))
+        SerdeError::Deserialize(format!("Failed to deserialize: {msg}", msg = msg))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,12 +26,12 @@ pub enum SerdeError {
 
 impl ser::Error for SerdeError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        SerdeError::Serialize(format!("Failed to serialize: {msg}", msg = msg))
+        SerdeError::Serialize(format!("Failed to serialize: {}", msg))
     }
 }
 
 impl de::Error for SerdeError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        SerdeError::Deserialize(format!("Failed to deserialize: {msg}", msg = msg))
+        SerdeError::Deserialize(format!("Failed to deserialize: {}", msg))
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -55,7 +55,7 @@ impl Node {
         command.arg("--ws-port");
         command.arg(self.ws_port.to_string());
         if let Some(rpc_port) = self.rpc_port {
-            command.arg(format!("--rpc-port {rpc_port}"));
+            command.arg(format!("--rpc-port {rpc_port}", rpc_port = rpc_port));
         };
 
         command

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -55,7 +55,7 @@ impl Node {
         command.arg("--ws-port");
         command.arg(self.ws_port.to_string());
         if let Some(rpc_port) = self.rpc_port {
-            command.arg(format!("--rpc-port {rpc_port}", rpc_port = rpc_port));
+            command.arg(format!("--rpc-port {}", rpc_port));
         };
 
         command


### PR DESCRIPTION
Fixes the `there is no argument named x` errors that I encounter when compiling with rustc 1.57.0. 
