### PR TITLE
Adds a para_id option to the generate-specs command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [[bin]]
-name = "pendulum_launch"
+name = "pendulum-launch"
 path = "src/bin/cli/main.rs"
 
 [lib]

--- a/src/bin/cli/app.rs
+++ b/src/bin/cli/app.rs
@@ -38,10 +38,12 @@ impl App {
                 Command::GenerateSpecs {
                     collator_bin,
                     name,
+                    para_id,
                     outdir,
                 } => self.generate_specs(
                     collator_bin.to_owned(),
                     name.to_owned(),
+                    para_id.to_owned(),
                     outdir.to_owned(),
                 )?,
             },
@@ -78,13 +80,15 @@ impl App {
         &self,
         bin: PathBuf,
         name: Option<String>,
+        para_id: Option<u32>,
         outdir: Option<PathBuf>,
     ) -> Result<()> {
         let bin = path_to_str(&bin)?;
         let name = name.unwrap_or_else(|| "local-chain".to_string());
+        let para_id = para_id.unwrap_or_else(|| 2000);
         let outdir = path_to_str(&outdir.unwrap_or(util::locate_project_root()?))?;
 
-        sub_command::generate_specs(bin, name, outdir)
+        sub_command::generate_specs(bin, name, para_id, outdir)
     }
 }
 

--- a/src/bin/cli/opt.rs
+++ b/src/bin/cli/opt.rs
@@ -20,6 +20,8 @@ pub enum Command {
         collator_bin: PathBuf,
         #[structopt(short, long, about = "File prefix")]
         name: Option<String>,
+        #[structopt(short = "i", long, about = "Para id")]
+        para_id: Option<u32>,
         #[structopt(short, long, parse(from_os_str), about = "Alternate output directory")]
         outdir: Option<PathBuf>,
     },

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,8 +10,10 @@ pub enum Error {
     NoConfig,
     #[error("Must provide valid path")]
     InvalidPath,
-    #[error("Process failed: {0:?}")]
+    #[error("Process failed: {0}")]
     ProcessFailed(String),
+    #[error("Invalid json value: {0}")]
+    InvalidJsonValue(String),
     #[error("{0}")]
     Io(#[from] io::Error),
     #[error("{0}")]


### PR DESCRIPTION
Allows a user to set a para_id in the plain spec before building the raw spec