### PR TITLE
Node trait + generate_docker patch

### DIFF
--- a/config/pendulum-launch.json
+++ b/config/pendulum-launch.json
@@ -16,7 +16,7 @@
       "bin": "../polkadot/target/release/polkadot",
       "chain": "./specs/rococo-custom-2-raw.json",
       "args": ["--bob", "--base-path=/tmp/relay/bob"],
-      "port": 30344,
+      "port": 30343,
       "ws_port": 9945,
       "rpc_port": null
     }

--- a/launch.json
+++ b/launch.json
@@ -24,7 +24,7 @@
                     "--enable-offchain-indexing",
                     "true"
                 ],
-                "port": 30344,
+                "port": 30343,
                 "ws_port": 8844,
                 "rpc_port": null
             },

--- a/launch.json
+++ b/launch.json
@@ -24,7 +24,7 @@
                     "--enable-offchain-indexing",
                     "true"
                 ],
-                "port": 30343,
+                "port": 30344,
                 "ws_port": 8844,
                 "rpc_port": null
             },

--- a/src/bin/cli/app.rs
+++ b/src/bin/cli/app.rs
@@ -65,6 +65,8 @@ impl App {
         }
 
         let mut config = deserialize_config(&self.0.config)?;
+        config.ensure_unique_ports()?;
+
         Launcher::new(&mut config, log)?.run()
     }
 
@@ -102,7 +104,9 @@ impl App {
 
     fn generate_docker(&self, out_dir: Option<PathBuf>) -> Result<()> {
         let config = deserialize_config(&self.0.config)?;
+        config.ensure_unique_ports()?;
         let out_dir = util::path_to_string(&out_dir.unwrap_or(util::locate_project_root()?))?;
+
         sub_command::generate_docker(config, out_dir)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,12 +53,9 @@ impl Config {
             node.ports()
                 .iter()
                 .flatten()
-                .try_for_each(|p| match ports.contains(p) {
-                    true => Err(Error::PortInUse(*p)),
-                    false => {
-                        ports.insert(*p);
-                        Ok(())
-                    }
+                .try_for_each(|p| match ports.insert(*p) {
+                    true => Ok(()),
+                    false => Err(Error::PortInUse(*p)),
                 })
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,10 @@
 use crate::{
     error::{Error, Result, SerdeError},
-    node::{Collator, Validator},
+    node::{Collator, Node, Validator},
     Task,
 };
 use serde::{Deserialize, Serialize};
-use std::{fs, path::PathBuf};
+use std::{collections::HashSet, fs, path::PathBuf};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
@@ -44,5 +44,34 @@ impl Config {
         let validator_tasks = self.validators.iter().map(|v| v.create_task());
         let collator_tasks = self.collators.iter().map(|c| c.create_task());
         validator_tasks.chain(collator_tasks).collect()
+    }
+
+    pub fn ensure_unique_ports(&self) -> Result<()> {
+        let mut ports: HashSet<u16> = HashSet::new();
+
+        fn check_single_node(ports: &mut HashSet<u16>, node: &impl Node) -> Result<()> {
+            node.ports()
+                .iter()
+                .flatten()
+                .try_for_each(|p| match ports.contains(p) {
+                    true => Err(Error::PortInUse(*p)),
+                    false => {
+                        ports.insert(*p);
+                        Ok(())
+                    }
+                })
+        }
+
+        self.validators
+            .iter()
+            .map(|n| check_single_node(&mut ports, n))
+            .collect::<Result<()>>()?;
+
+        self.collators
+            .iter()
+            .map(|n| check_single_node(&mut ports, n))
+            .collect::<Result<()>>()?;
+
+        Ok(())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ impl Config {
     pub fn ensure_unique_ports(&self) -> Result<()> {
         let mut ports: HashSet<u16> = HashSet::new();
 
-        fn check_single_node(ports: &mut HashSet<u16>, node: &impl Node) -> Result<()> {
+        fn check_node(ports: &mut HashSet<u16>, node: &impl Node) -> Result<()> {
             node.ports()
                 .iter()
                 .flatten()
@@ -62,16 +62,10 @@ impl Config {
                 })
         }
 
-        self.validators
-            .iter()
-            .map(|n| check_single_node(&mut ports, n))
-            .collect::<Result<()>>()?;
+        let check_validator = |v| check_node(&mut ports, v);
+        self.validators.iter().try_for_each(check_validator)?;
 
-        self.collators
-            .iter()
-            .map(|n| check_single_node(&mut ports, n))
-            .collect::<Result<()>>()?;
-
-        Ok(())
+        let check_collator = |c| check_node(&mut ports, c);
+        self.collators.iter().try_for_each(check_collator)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     NoConfig,
     #[error("Must provide valid path")]
     InvalidPath,
+    #[error("Port {0} used more than once")]
+    PortInUse(u16),
     #[error("Uninitialized: {0}")]
     Uninitialized(String),
     #[error("Process failed: {0}")]

--- a/src/node/collator.rs
+++ b/src/node/collator.rs
@@ -1,4 +1,4 @@
-use super::{AsCommand, Node};
+use super::{AsCommand, BaseNode, Node};
 use crate::{error::Result, util, PathBuffer, Task};
 use serde::{Deserialize, Serialize};
 use std::process;
@@ -33,45 +33,32 @@ impl CollatorRelay {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Collator {
-    inner: Node,
+    inner: BaseNode,
     relay: CollatorRelay,
 }
 
 impl Collator {
     #[inline]
-    pub fn new(inner: Node, relay: CollatorRelay) -> Self {
+    pub fn new(inner: BaseNode, relay: CollatorRelay) -> Self {
         Self { inner, relay }
     }
 
     pub fn create_task(&self) -> Result<Task> {
         let mut command = self.inner.as_command_internal()?;
-        command.args(self.get_args()?);
+        command.args(self.args()?);
 
         Ok(Task::new(command))
     }
+}
 
+impl Node for Collator {
     #[inline]
-    pub fn name(&self) -> &str {
+    fn name(&self) -> &str {
         &self.inner.name
     }
 
-    #[inline]
-    pub fn docker_file(&self) -> Result<String> {
-        self.inner.docker_file()
-    }
 
-    pub fn ports(&self) -> [Option<u16>; 6] {
-        [
-            self.inner.port.into(),
-            self.inner.ws_port.into(),
-            self.inner.rpc_port,
-            self.relay.port.into(),
-            self.relay.ws_port.into(),
-            self.relay.rpc_port,
-        ]
-    }
-
-    fn get_args(&self) -> Result<Vec<String>> {
+    fn args(&self) -> Result<Vec<String>> {
         let mut args = vec![
             "--collator".to_owned(),
             "--".to_owned(),
@@ -97,12 +84,28 @@ impl Collator {
 
         Ok(args)
     }
+
+    fn ports(&self) -> Vec<Option<u16>> {
+        vec![
+            self.inner.port.into(),
+            self.inner.ws_port.into(),
+            self.inner.rpc_port,
+            self.relay.port.into(),
+            self.relay.ws_port.into(),
+            self.relay.rpc_port,
+        ]
+    }
+
+    #[inline]
+    fn docker_file(&self) -> Result<String> {
+        self.inner.docker_file()
+    }
 }
 
 impl AsCommand for Collator {
     fn as_command_internal(&self) -> Result<process::Command> {
         let mut command = self.inner.as_command_internal()?;
-        command.args(self.get_args()?);
+        command.args(self.args()?);
 
         Ok(command)
     }
@@ -110,7 +113,7 @@ impl AsCommand for Collator {
     fn as_command_external(&self) -> Result<String> {
         let mut command = self.inner.as_command_external()?;
         command.push(' ');
-        command.push_str(&self.get_args()?.join(" "));
+        command.push_str(&self.args()?.join(" "));
 
         Ok(command)
     }

--- a/src/node/collator.rs
+++ b/src/node/collator.rs
@@ -57,7 +57,6 @@ impl Node for Collator {
         &self.inner.name
     }
 
-
     fn args(&self) -> Result<Vec<String>> {
         let mut args = vec![
             "--collator".to_owned(),
@@ -86,14 +85,22 @@ impl Node for Collator {
     }
 
     fn ports(&self) -> Vec<Option<u16>> {
-        vec![
+        let mut ports = self.inner.ports();
+        ports.append(&mut vec![
+            self.relay.port.into(),
+            self.relay.ws_port.into(),
+            self.relay.rpc_port,
+        ]);
+
+        ports
+        /* vec![
             self.inner.port.into(),
             self.inner.ws_port.into(),
             self.inner.rpc_port,
             self.relay.port.into(),
             self.relay.ws_port.into(),
             self.relay.rpc_port,
-        ]
+        ] */
     }
 
     #[inline]

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -109,7 +109,7 @@ impl Node for BaseNode {
 
     #[inline]
     fn ports(&self) -> Vec<Option<u16>> {
-        vec![self.port.into(), self.ws_port.into(), self.rpc_port.into()]
+        vec![self.port.into(), self.ws_port.into(), self.rpc_port]
     }
 
     fn docker_file(&self) -> Result<String> {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -109,7 +109,7 @@ impl Node for BaseNode {
 
     #[inline]
     fn ports(&self) -> Vec<Option<u16>> {
-        vec![]
+        vec![self.port.into(), self.ws_port.into(), self.rpc_port.into()]
     }
 
     fn docker_file(&self) -> Result<String> {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -12,13 +12,20 @@ use std::{
     sync::Arc,
 };
 
+pub trait Node {
+    fn name(&self) -> &str;
+    fn args(&self) -> Result<Vec<String>>;
+    fn ports(&self) -> Vec<Option<u16>>;
+    fn docker_file(&self) -> Result<String>;
+}
+
 pub trait AsCommand {
     fn as_command_internal(&self) -> Result<process::Command>;
     fn as_command_external(&self) -> Result<String>;
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct Node {
+pub struct BaseNode {
     name: String,
     bin: PathBuffer,
     chain: PathBuffer,
@@ -29,7 +36,7 @@ pub struct Node {
     rpc_port: Option<u16>,
 }
 
-impl Node {
+impl BaseNode {
     pub fn new(
         name: Option<&str>,
         bin: &str,
@@ -42,7 +49,7 @@ impl Node {
     ) -> Self {
         let name = match name {
             Some(name) => name.to_owned(),
-            None => Self::get_name(bin, ws_port),
+            None => Self::create_name(bin, ws_port),
         };
 
         let args = args.into_iter().map(|arg| arg.to_owned()).collect();
@@ -65,19 +72,18 @@ impl Node {
     }
 
     #[inline]
-    fn get_name(bin: &str, ws_port: u16) -> String {
+    fn create_name(bin: &str, ws_port: u16) -> String {
         format!("{}-{}", bin, ws_port)
     }
+}
 
+impl Node for BaseNode {
     #[inline]
-    fn docker_file(&self) -> Result<String> {
-        match &self.dockerfile {
-            Some(path) => util::path_to_string(path.as_ref()),
-            None => Ok("Dockerfile".to_owned()),
-        }
+    fn name(&self) -> &str {
+        &self.name
     }
 
-    fn get_args(&self) -> Result<Vec<String>> {
+    fn args(&self) -> Result<Vec<String>> {
         let mut args = self.args.to_owned();
         args.append(
             vec![
@@ -100,9 +106,21 @@ impl Node {
 
         Ok(args)
     }
+
+    #[inline]
+    fn ports(&self) -> Vec<Option<u16>> {
+        vec![]
+    }
+
+    fn docker_file(&self) -> Result<String> {
+        match &self.dockerfile {
+            Some(path) => util::path_to_string(path.as_ref()),
+            None => Ok("Dockerfile".to_owned()),
+        }
+    }
 }
 
-impl AsCommand for Node {
+impl AsCommand for BaseNode {
     fn as_command_internal(&self) -> Result<process::Command> {
         let log = match &*Arc::clone(&LOG_DIR).read()? {
             Some(path) => {
@@ -114,14 +132,14 @@ impl AsCommand for Node {
         };
 
         let mut command = process::Command::new(self.bin.as_ref());
-        command.stdout(log).args(self.get_args()?);
+        command.stdout(log).args(self.args()?);
 
         Ok(command)
     }
 
     fn as_command_external(&self) -> Result<String> {
         let mut command = vec![util::path_to_string(self.bin.as_ref())?];
-        command.append(self.get_args()?.as_mut());
+        command.append(self.args()?.as_mut());
 
         Ok(command.join(" "))
     }

--- a/src/node/validator.rs
+++ b/src/node/validator.rs
@@ -1,14 +1,14 @@
-use super::{AsCommand, Node};
+use super::{AsCommand, BaseNode, Node};
 use crate::{error::Result, Task};
 use serde::{Deserialize, Serialize};
 use std::process;
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct Validator(Node);
+pub struct Validator(BaseNode);
 
 impl Validator {
     #[inline]
-    pub fn new(node: Node) -> Self {
+    pub fn new(node: BaseNode) -> Self {
         Self(node)
     }
 
@@ -18,18 +18,43 @@ impl Validator {
     }
 }
 
-impl AsRef<Node> for Validator {
-    fn as_ref(&self) -> &Node {
+impl AsRef<BaseNode> for Validator {
+    fn as_ref(&self) -> &BaseNode {
         &self.0
+    }
+}
+
+impl Node for Validator {
+    fn name(&self) -> &str {
+        self.as_ref().name()
+    }
+
+    fn args(&self) -> Result<Vec<String>> {
+        Ok(vec!["--validator".to_owned()])
+    }
+
+    fn ports(&self) -> Vec<Option<u16>> {
+        self.as_ref().ports()
+    }
+
+    fn docker_file(&self) -> Result<String> {
+        self.0.docker_file()
     }
 }
 
 impl AsCommand for Validator {
     fn as_command_internal(&self) -> Result<process::Command> {
-        self.0.as_command_internal()
+        let mut command = self.as_ref().as_command_internal()?;
+        command.args(self.args()?);
+
+        Ok(command)
     }
 
     fn as_command_external(&self) -> Result<String> {
-        self.0.as_command_external()
+        let mut command = self.as_ref().as_command_external()?;
+        command.push(' ');
+        command.push_str(&self.args()?.join(" "));
+
+        Ok(command)
     }
 }

--- a/src/sub_command/generate_docker.rs
+++ b/src/sub_command/generate_docker.rs
@@ -5,9 +5,6 @@ use crate::{
 };
 use std::fs;
 
-// Static ports exposed in the base image
-const INTERNAL_PORTS: [u16; 6] = [8844, 30344, 9944, 8855, 30355, 9955];
-
 pub fn generate_docker(config: Config, out_dir: String) -> Result<()> {
     let out_file = format!("{}/docker-compose.yml", out_dir);
     let contents = generate_contents(&config)?;
@@ -62,9 +59,7 @@ where
         node.docker_file()?
     );
 
-    map_ports(node)
-        .into_iter()
-        .for_each(|port| service.push_str(&format!("\n      {}", port)));
+    map_ports(node).for_each(|port| service.push_str(&format!("\n      {}", port)));
 
     service.push_str(&format!(
         "\n    restart: on-failure\n    command: {}",
@@ -74,14 +69,12 @@ where
     Ok(service)
 }
 
-fn map_ports<N>(node: &N) -> Vec<String>
+fn map_ports<N>(node: &N) -> impl Iterator<Item = String>
 where
     N: Node,
 {
     node.ports()
         .into_iter()
         .flatten()
-        .zip(INTERNAL_PORTS)
-        .map(|(outer_port, inner_port)| format!("- \"{}:{}\"", outer_port, inner_port))
-        .collect()
+        .map(|port| format!("- \"{}:{}\"", port, port))
 }

--- a/src/sub_command/generate_docker.rs
+++ b/src/sub_command/generate_docker.rs
@@ -26,7 +26,7 @@ services:"#,
     Ok(docker_compose)
 }
 
-fn write_service<N>(docker_compose: &mut String, nodes: &Vec<N>) -> Result<()>
+fn write_service<N>(docker_compose: &mut String, nodes: &[N]) -> Result<()>
 where
     N: Node + AsCommand,
 {


### PR DESCRIPTION
Adds the node::Node trait, capturing generic behavior and allow for use in generic consumers.  I used the Node trait to patch validator generation into the generate_docker command.